### PR TITLE
Add ipv6_dhcpd option to advanced-dhcpdns

### DIFF
--- a/advanced-dhcpdns.asp
+++ b/advanced-dhcpdns.asp
@@ -9,7 +9,7 @@ No part of this file may be used without permission.
 <content>
 	<script type="text/javascript">
 
-		//	<% nvram("dnsmasq_q,ipv6_radvd,dhcpd_dmdns,dns_addget,dhcpd_gwmode,dns_intcpt,dhcpd_slt,dhcpc_minpkt,dnsmasq_custom,dnsmasq_norw,dhcpd_lmax,dhcpc_custom,dns_norebind,dhcpd_static_only"); %>
+		//	<% nvram("dnsmasq_q,ipv6_radvd,ipv6_dhcpd,dhcpd_dmdns,dns_addget,dhcpd_gwmode,dns_intcpt,dhcpd_slt,dhcpc_minpkt,dnsmasq_custom,dnsmasq_norw,dhcpd_lmax,dhcpc_custom,dns_norebind,dhcpd_static_only"); %>
 
 		if ((isNaN(nvram.dhcpd_lmax)) || ((nvram.dhcpd_lmax *= 1) < 1)) nvram.dhcpd_lmax = 255;
 
@@ -46,6 +46,7 @@ No part of this file may be used without permission.
 			fom.dhcpc_minpkt.value = E('_f_dhcpc_minpkt').checked ? 1 : 0;
 			fom.dhcpd_static_only.value = E('_f_dhcpd_static_only').checked ? '1' : '0';
 			fom.ipv6_radvd.value = E('_f_ipv6_radvd').checked ? '1' : '0';
+			fom.ipv6_dhcpd.value = E('_f_ipv6_dhcpd').checked ? '1' : '0';
 
 			fom.dnsmasq_q.value = 0;
 			if (fom.f_dnsmasq_q4.checked) fom.dnsmasq_q.value |= 1;
@@ -111,6 +112,7 @@ No part of this file may be used without permission.
 		<input type="hidden" name="dhcpc_minpkt">
 		<input type="hidden" name="dhcpd_static_only">
 		<input type="hidden" name="ipv6_radvd">
+		<input type='hidden' name="ipv6_dhcpd">
 		<input type="hidden" name="dnsmasq_q">
 
 		<div class="box" data-box="dhcp-server">
@@ -130,7 +132,8 @@ No part of this file may be used without permission.
 							value: (nvram.dhcpd_slt < 1) ? nvram.dhcpd_slt : 1 },
 						{ name: 'f_dhcpd_slt', type: 'text', maxlen: 5, size: 8, prefix: '<span id="_dhcpd_sltman"> ', suffix: 'minutes</span>',
 							value: (nvram.dhcpd_slt >= 1) ? nvram.dhcpd_slt : 3600 } ] },
-					{ title: 'Announce IPv6 on LAN', name: 'f_ipv6_radvd', type: 'checkbox', value: nvram.ipv6_radvd == '1' },
+					{ title: 'Announce IPv6 on LAN (SLAAC)', name: 'f_ipv6_radvd', type: 'checkbox', value: nvram.ipv6_radvd == '1' },
+					{ title: 'Announce IPv6 on LAN (DHCP)', name: 'f_ipv6_dhcpd', type: 'checkbox', value: nvram.ipv6_dhcpd == '1' },
 					{ title: 'Mute dhcpv4 logging', name: 'f_dnsmasq_q4', type: 'checkbox', value: (nvram.dnsmasq_q & 1) },
 					{ title: 'Mute dhcpv6 logging', name: 'f_dnsmasq_q6', type: 'checkbox', value: (nvram.dnsmasq_q & 2) },
 					{ title: 'Mute RA logging', name: 'f_dnsmasq_qr', type: 'checkbox', value: (nvram.dnsmasq_q & 4) },


### PR DESCRIPTION
I don't have the ability to test this, but this brings advaced-dhcpdns.asp in line with https://github.com/tomatofirmware/tomato/blob/cca9a2e885351d7afb95428c05a50f70b46d466c/release/src/router/www/advanced-dhcpdns.asp and should fix https://github.com/Jackysi/advancedtomato/issues/132