### PR TITLE
Make VPN Client Connection Actions Noticeable

### DIFF
--- a/vpn-client.asp
+++ b/vpn-client.asp
@@ -387,7 +387,7 @@ No part of this file may be used without permission.
 					htmlOut += ('<li><a href="javascript:sectSelect('+i+', \''+sections[j][0]+'\')" id="'+t+'-'+sections[j][0]+'-tab">'+sections[j][1]+'</a></li>');
 				}
 
-				var action = (eval('vpn'+(i+1)+'up') ? 'title="Stop VPN Client ' + (i+1) + '"><i class="icon-stop"></i>' : 'title="Start VPN Client ' + (i+1) + '"><i class="icon-play"></i>');
+				var action = (eval('vpn'+(i+1)+'up') ? 'title="Stop VPN Client ' + (i+1) + '"><span class="btn btn-danger btn-small">Stop Now</span>' : 'title="Start VPN Client ' + (i+1) + '"><span class="btn btn-success btn-small">Start Now</span>');
 				var status = (!eval('vpn'+(i+1)+'up') ? '<small style="color: red">(Stopped)</small>' : '<small style="color: green;">(Running)</small>');
 
 				htmlOut += '</ul>'


### PR DESCRIPTION
The play/stop icons used for controlling the VPN connection aren't
noticeable enough, especially on larger monitors. Switch them to colored
`btn` components.

Setup documentation, such as [this](https://www.privateinternetaccess.com/forum/discussion/110/updated-tomato-setup-for-newer-branches-including-tomatousb/p1), refer to the Start Now / Stop Now buttons which can't be found in the current version of AT.